### PR TITLE
Add n8n desktop python example project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # p8p-automate
+
+Este repositorio contiene ejemplos y proyectos automatizados. Consulta la carpeta `n8n_desktop_python/` para un ejemplo de app de escritorio inspirada en n8n.

--- a/n8n_desktop_python/README.md
+++ b/n8n_desktop_python/README.md
@@ -1,0 +1,75 @@
+# n8n Desktop Python
+
+Esta aplicación emula la lógica de n8n en un entorno de escritorio usando Python. Utiliza Flask como backend web y PyWebview para ejecutarse como app nativa.
+
+## Instalación
+
+```bash
+pip install -r requirements.txt
+```
+
+## Cómo correr
+
+```bash
+python app.py
+```
+
+Si deseas correr el servidor Flask sin PyWebview, puedes establecer la variable de entorno `FLASK_ONLY=1`.
+
+## Crear nuevo nodo
+
+1. Crea un archivo `.py` dentro de la carpeta `nodes/`.
+2. Implementa una función `ejecutar(entrada: dict) -> dict`.
+3. El resultado retornado se pasará al siguiente nodo del flujo.
+
+## Crear nuevo flujo
+
+1. Genera un archivo `.json` en la carpeta `flujos/`.
+2. Define una lista de pasos donde cada paso indica el `id`, el `tipo` (nombre del nodo) y sus `params`.
+
+Ejemplo:
+
+```json
+[
+  {"id": "1", "tipo": "leer_url", "params": {"url": "https://example.com"}},
+  {"id": "2", "tipo": "extraer_titulo", "params": {}},
+  {"id": "3", "tipo": "guardar_txt", "params": {"archivo": "titulo.txt"}}
+]
+```
+
+## Empaquetar como ejecutable
+
+Para crear un ejecutable puedes usar PyInstaller:
+
+```bash
+pyinstaller --onefile --add-data "templates;templates" --add-data "static;static" app.py
+```
+
+Esto generará un archivo `dist/app.exe` (en sistemas Windows). Cambia la extensión a `.txt` si no deseas generar binarios directamente.
+
+## Estructura del proyecto
+
+```
+app.py
+backend/
+  flujo_engine.py
+nodes/
+  leer_url.py
+  extraer_titulo.py
+  guardar_txt.py
+flujos/
+  flujo_demo.json
+templates/
+  index.html
+static/
+  style.css
+requirements.txt
+```
+
+## Funcionalidades clave
+
+- Carga flujos desde archivos JSON.
+- Ejecución dinámica de nodos Python.
+- Flujo encadenado: la salida de un nodo es la entrada del siguiente.
+- Manejo simple de errores: si un nodo falla, se detiene la ejecución y se registra el error.
+- Interfaz web con resultados de cada paso y editor básico de nodos.

--- a/n8n_desktop_python/app.py
+++ b/n8n_desktop_python/app.py
@@ -1,0 +1,40 @@
+import os
+from flask import Flask, render_template, request, jsonify
+import webview
+from backend.flujo_engine import ejecutar_flujo
+
+app = Flask(__name__)
+
+@app.route('/')
+def index():
+    flujos = [f for f in os.listdir('flujos') if f.endswith('.json')]
+    nodes = [f for f in os.listdir('nodes') if f.endswith('.py')]
+    return render_template('index.html', flujos=flujos, nodes=nodes)
+
+@app.route('/run', methods=['POST'])
+def run_flujo():
+    data = request.get_json()
+    flujo_path = os.path.join('flujos', data['flujo'])
+    resultados = ejecutar_flujo(flujo_path)
+    return jsonify(resultados)
+
+@app.route('/node/<nombre>', methods=['GET', 'POST'])
+def editar_nodo(nombre):
+    ruta = os.path.join('nodes', nombre)
+    if request.method == 'POST':
+        codigo = request.form['code']
+        with open(ruta, 'w') as f:
+            f.write(codigo)
+        return 'guardado'
+    with open(ruta) as f:
+        return f.read()
+
+def start():
+    if os.environ.get('FLASK_ONLY'):
+        app.run(debug=True)
+    else:
+        webview.create_window('n8n Desktop Python', app)
+        webview.start()
+
+if __name__ == '__main__':
+    start()

--- a/n8n_desktop_python/backend/flujo_engine.py
+++ b/n8n_desktop_python/backend/flujo_engine.py
@@ -1,0 +1,36 @@
+import json
+import importlib.util
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+NODES_DIR = BASE_DIR / 'nodes'
+
+
+def cargar_modulo(nombre):
+    ruta = NODES_DIR / f'{nombre}.py'
+    spec = importlib.util.spec_from_file_location(nombre, ruta)
+    modulo = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(modulo)
+    return modulo
+
+
+def ejecutar_flujo(ruta_flujo):
+    with open(ruta_flujo) as f:
+        pasos = json.load(f)
+
+    datos = {}
+    logs = []
+    for paso in pasos:
+        tipo = paso['tipo']
+        params = paso.get('params', {})
+        modulo = cargar_modulo(tipo)
+        entrada = {'params': params}
+        entrada.update(datos)
+        try:
+            salida = modulo.ejecutar(entrada)
+            datos.update(salida)
+            logs.append({'id': paso['id'], 'nodo': tipo, 'salida': salida})
+        except Exception as e:
+            logs.append({'id': paso['id'], 'nodo': tipo, 'error': str(e)})
+            break
+    return logs

--- a/n8n_desktop_python/flujos/flujo_demo.json
+++ b/n8n_desktop_python/flujos/flujo_demo.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": "1",
+    "tipo": "leer_url",
+    "params": {"url": "https://example.com"}
+  },
+  {
+    "id": "2",
+    "tipo": "extraer_titulo",
+    "params": {}
+  },
+  {
+    "id": "3",
+    "tipo": "guardar_txt",
+    "params": {"archivo": "titulo.txt"}
+  }
+]

--- a/n8n_desktop_python/nodes/extraer_titulo.py
+++ b/n8n_desktop_python/nodes/extraer_titulo.py
@@ -1,0 +1,7 @@
+from bs4 import BeautifulSoup
+
+def ejecutar(entrada):
+    html = entrada.get('html')
+    soup = BeautifulSoup(html, 'html.parser')
+    titulo = soup.title.string if soup.title else ''
+    return {'titulo': titulo}

--- a/n8n_desktop_python/nodes/guardar_txt.py
+++ b/n8n_desktop_python/nodes/guardar_txt.py
@@ -1,0 +1,7 @@
+
+def ejecutar(entrada):
+    texto = entrada.get('titulo') or entrada.get('texto')
+    nombre = entrada['params'].get('archivo', 'salida.txt')
+    with open(nombre, 'w', encoding='utf-8') as f:
+        f.write(texto)
+    return {'archivo': nombre}

--- a/n8n_desktop_python/nodes/leer_url.py
+++ b/n8n_desktop_python/nodes/leer_url.py
@@ -1,0 +1,6 @@
+import requests
+
+def ejecutar(entrada):
+    url = entrada.get('url') or entrada['params'].get('url')
+    response = requests.get(url)
+    return {'html': response.text}

--- a/n8n_desktop_python/requirements.txt
+++ b/n8n_desktop_python/requirements.txt
@@ -1,0 +1,4 @@
+flask
+pywebview
+requests
+beautifulsoup4

--- a/n8n_desktop_python/static/style.css
+++ b/n8n_desktop_python/static/style.css
@@ -1,0 +1,2 @@
+body {font-family: Arial, sans-serif;}
+pre {max-height: 300px; overflow: auto;}

--- a/n8n_desktop_python/templates/index.html
+++ b/n8n_desktop_python/templates/index.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>n8n Desktop Python</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+</head>
+<body class="p-4">
+  <h1>n8n Desktop Python</h1>
+  <div class="mb-3">
+    <label class="form-label">Flujo</label>
+    <select id="flujo" class="form-select">
+      {% for f in flujos %}
+        <option value="{{ f }}">{{ f }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <button id="run" class="btn btn-primary">Ejecutar Flujo</button>
+  <pre id="resultado" class="mt-3 bg-light p-2"></pre>
+  <hr>
+  <h2>Editar Nodo</h2>
+  <select id="node-select" class="form-select mb-2">
+    {% for n in nodes %}
+      <option value="{{ n }}">{{ n }}</option>
+    {% endfor %}
+  </select>
+  <textarea id="code" class="form-control" rows="10"></textarea>
+  <button id="save" class="btn btn-success mt-2">Guardar</button>
+  <script>
+    function cargarNodo(){
+      var n = $('#node-select').val();
+      $.get('/node/' + n, function(data){
+        $('#code').val(data);
+      });
+    }
+    $('#node-select').change(cargarNodo);
+    $('#save').click(function(){
+      var n = $('#node-select').val();
+      $.post('/node/' + n, {code: $('#code').val()}, function(){
+        alert('Guardado');
+      });
+    });
+    $('#run').click(function(){
+      $.ajax({
+        url:'/run',
+        method:'POST',
+        contentType:'application/json',
+        data: JSON.stringify({flujo: $('#flujo').val()}),
+        success:function(data){
+          $('#resultado').text(JSON.stringify(data, null, 2));
+        }
+      });
+    });
+    $(document).ready(function(){
+      cargarNodo();
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `n8n_desktop_python` project implementing a simple n8n-inspired desktop app
- implement `app.py` Flask backend with PyWebview integration
- create `flujo_engine.py` to load and run nodes
- add example nodes and demo flow
- add simple Bootstrap interface with code editor
- document usage in a new README
- update root README with project pointer

## Testing
- `python -m py_compile n8n_desktop_python/**/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68407d3406c083328f2b9874938833dd