### PR TITLE
Add AI nodes and demo flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,31 @@
 # p8p-automate
 
-Este repositorio contiene ejemplos y proyectos automatizados. Consulta la carpeta `n8n_desktop_python/` para un ejemplo de app de escritorio inspirada en n8n.
+Este repositorio contiene ejemplos y proyectos automatizados. Revisa la carpeta `n8n_desktop_python/` para una app de escritorio inspirada en n8n.
+
+## Nodos de IA
+
+En la raíz del proyecto se incluyen dos nodos para conectarse a modelos de lenguaje:
+
+- `nodes/chatgpt_custom.py` utiliza la API de OpenAI.
+- `nodes/gemini_pro.py` usa la API de Google Generative AI.
+
+Cada nodo implementa la función `ejecutar(entrada: dict) -> dict` y puede ser importado dinámicamente por el motor de flujos.
+
+### Instalación de dependencias
+
+```bash
+pip install openai google-generativeai
+```
+
+### Crear nuevos nodos
+
+1. Crea un archivo dentro de la carpeta `nodes/`.
+2. Define una función `ejecutar(entrada: dict) -> dict` que procese los parámetros y devuelva un diccionario.
+3. El nombre del archivo debe coincidir con el campo `tipo` del flujo JSON.
+
+### Integrar en el flujo P8P
+
+Los flujos se definen como listas de pasos en la carpeta `flujos/`. Un ejemplo se encuentra en `flujos/flujo_ia.json`.
+Al ejecutar el motor, la salida de cada nodo se pasa como entrada al siguiente.
+
+Cada nodo es modular, por lo que es sencillo incorporar soporte para otros modelos (por ejemplo Ollama u opciones locales) creando nuevos archivos en `nodes/`.

--- a/flujos/flujo_ia.json
+++ b/flujos/flujo_ia.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "1",
+    "tipo": "chatgpt_custom",
+    "params": {
+      "api_key": "TU_OPENAI_API_KEY",
+      "mensaje": "Explicame el sentido del sufrimiento segun Juan Pablo II",
+      "instruccion": "Sos un teologo catolico que escribe para jovenes"
+    }
+  },
+  {
+    "id": "2",
+    "tipo": "guardar_txt",
+    "params": {
+      "archivo": "respuesta_ia.txt"
+    }
+  }
+]

--- a/nodes/chatgpt_custom.py
+++ b/nodes/chatgpt_custom.py
@@ -1,0 +1,30 @@
+import openai
+
+
+def ejecutar(entrada: dict) -> dict:
+    """Envía un mensaje a la API de OpenAI y retorna la respuesta."""
+    params = entrada.get('params', {})
+    api_key = entrada.get('api_key') or params.get('api_key')
+    mensaje = entrada.get('mensaje') or params.get('mensaje')
+    modelo = entrada.get('modelo') or params.get('modelo', 'gpt-4')
+    instruccion = entrada.get('instruccion') or params.get('instruccion')
+
+    if not api_key:
+        raise ValueError('Falta api_key para OpenAI')
+    if not mensaje:
+        raise ValueError('Falta mensaje para enviar al modelo')
+
+    openai.api_key = api_key
+
+    messages = []
+    if instruccion:
+        messages.append({"role": "system", "content": instruccion})
+    messages.append({"role": "user", "content": mensaje})
+
+    respuesta = openai.ChatCompletion.create(
+        model=modelo,
+        messages=messages
+    )
+
+    contenido = respuesta.choices[0].message.content.strip()
+    return {'respuesta': contenido}

--- a/nodes/gemini_pro.py
+++ b/nodes/gemini_pro.py
@@ -1,0 +1,20 @@
+import google.generativeai as genai
+
+
+def ejecutar(entrada: dict) -> dict:
+    """Utiliza Google Generative AI para obtener una respuesta."""
+    params = entrada.get('params', {})
+    api_key = entrada.get('api_key') or params.get('api_key')
+    mensaje = entrada.get('mensaje') or params.get('mensaje')
+
+    if not api_key:
+        raise ValueError('Falta api_key para Gemini')
+    if not mensaje:
+        raise ValueError('Falta mensaje para enviar al modelo')
+
+    genai.configure(api_key=api_key)
+    model = genai.GenerativeModel('gemini-pro')
+    respuesta = model.generate_content(mensaje)
+    texto = respuesta.text if hasattr(respuesta, 'text') else str(respuesta)
+
+    return {'respuesta': texto}


### PR DESCRIPTION
## Summary
- add ChatGPT node and Gemini node under `nodes/`
- provide example flow `flujo_ia.json`
- extend README with installation and node integration instructions

## Testing
- `python -m py_compile nodes/chatgpt_custom.py nodes/gemini_pro.py`

------
https://chatgpt.com/codex/tasks/task_e_68407f98bbe88332901a9d0f47aa320f