### PR TITLE
Add import/export interface with logo

### DIFF
--- a/P8P/README.md
+++ b/P8P/README.md
@@ -1,6 +1,7 @@
 # P8P
 
 Plataforma local y visual para automatizar tareas mediante flujos de nodos Python.
+Incluye un logotipo inspirado en n8n con la "P" de Python.
 
 ## Ejecución
 
@@ -14,7 +15,8 @@ Establece `FLASK_ONLY=1` si no deseas usar PyWebview.
 
 1. Selecciona un flujo en la página principal.
 2. Haz clic en *Ejecutar flujo* para ver los resultados paso a paso.
-3. Cambia al modo avanzado para editar el código de cualquier nodo.
+3. Descarga o carga archivos JSON para compartir tus flujos.
+4. Cambia al modo avanzado para editar el código de cualquier nodo.
 
 ## Crear nuevos flujos
 

--- a/P8P/app.py
+++ b/P8P/app.py
@@ -1,5 +1,5 @@
 import os
-from flask import Flask, render_template, request, jsonify
+from flask import Flask, render_template, request, jsonify, send_from_directory
 import webview
 from backend.flujo_engine import ejecutar_flujo
 
@@ -21,6 +21,21 @@ def run_flujo():
     flujo_path = os.path.join('flujos', data['flujo'])
     resultados = ejecutar_flujo(flujo_path)
     return jsonify(resultados)
+
+@app.route('/download/<path:archivo>')
+def download_flujo(archivo):
+    return send_from_directory('flujos', archivo, as_attachment=True)
+
+@app.route('/upload', methods=['POST'])
+def upload_flujo():
+    archivo = request.files.get('file')
+    carpeta = request.form.get('carpeta', '')
+    ruta = os.path.join('flujos', carpeta)
+    os.makedirs(ruta, exist_ok=True)
+    if archivo:
+        archivo.save(os.path.join(ruta, archivo.filename))
+        return 'subido'
+    return 'no-file', 400
 
 @app.route('/node/<nombre>', methods=['GET', 'POST'])
 def editar_nodo(nombre):

--- a/P8P/static/logo.svg
+++ b/P8P/static/logo.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <circle cx="40" cy="40" r="30" fill="#306998"/>
+  <circle cx="160" cy="40" r="30" fill="#FFD43B"/>
+  <circle cx="100" cy="160" r="30" fill="#306998"/>
+  <line x1="40" y1="40" x2="160" y2="40" stroke="#333" stroke-width="10"/>
+  <line x1="40" y1="40" x2="100" y2="160" stroke="#333" stroke-width="10"/>
+  <line x1="160" y1="40" x2="100" y2="160" stroke="#333" stroke-width="10"/>
+  <text x="50%" y="60%" text-anchor="middle" font-size="80" fill="#ffffff" font-family="Arial" dy=".35em">P</text>
+</svg>

--- a/P8P/static/style.css
+++ b/P8P/static/style.css
@@ -1,2 +1,3 @@
 body {font-family: Arial, sans-serif;}
 pre {max-height: 300px; overflow: auto;}
+h1 img {vertical-align: middle;}

--- a/P8P/templates/index.html
+++ b/P8P/templates/index.html
@@ -8,7 +8,7 @@
   <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 </head>
 <body class="p-4">
-  <h1>P8P</h1>
+  <h1><img src="{{ url_for('static', filename='logo.svg') }}" alt="logo" width="50" class="me-2">P8P</h1>
   <div class="mb-3">
     <label class="form-label">Flujo</label>
     <select id="flujo" class="form-select">
@@ -21,7 +21,10 @@
       {% endfor %}
     </select>
   </div>
-  <button id="run" class="btn btn-primary">Ejecutar Flujo</button>
+  <button id="run" class="btn btn-primary me-2">Ejecutar Flujo</button>
+  <button id="download" class="btn btn-secondary me-2">Descargar JSON</button>
+  <input type="file" id="flujo-file" class="form-control d-inline w-auto"/>
+  <button id="upload" class="btn btn-secondary">Cargar JSON</button>
   <div class="form-check mt-3">
     <input class="form-check-input" type="checkbox" id="toggle-advanced">
     <label class="form-check-label" for="toggle-advanced">Modo Avanzado</label>
@@ -60,6 +63,27 @@
         data: JSON.stringify({flujo: $('#flujo').val()}),
         success:function(data){
           $('#resultado').text(JSON.stringify(data, null, 2));
+        }
+      });
+    });
+    $('#download').click(function(){
+      var f = $('#flujo').val();
+      window.location = '/download/' + f;
+    });
+    $('#upload').click(function(){
+      var data = new FormData();
+      var file = $('#flujo-file')[0].files[0];
+      if(!file){ alert('Selecciona un archivo'); return; }
+      data.append('file', file);
+      $.ajax({
+        url:'/upload',
+        method:'POST',
+        data:data,
+        processData:false,
+        contentType:false,
+        success:function(){
+          alert('Cargado');
+          location.reload();
         }
       });
     });


### PR DESCRIPTION
## Summary
- introduce ability to upload and download JSON flows
- display a Python themed logo
- adjust layout to include import/export controls
- document new UI in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840882397ec8332bf5967fff33cc627