### PR TITLE
Add dark mode and start-from-step option

### DIFF
--- a/P8P/README.md
+++ b/P8P/README.md
@@ -14,9 +14,11 @@ Establece `FLASK_ONLY=1` si no deseas usar PyWebview.
 ## Uso visual
 
 1. Selecciona un flujo en la página principal.
-2. Haz clic en *Ejecutar flujo* para ver los resultados paso a paso.
-3. Descarga o carga archivos JSON para compartir tus flujos.
-4. Cambia al modo avanzado para editar el código de cualquier nodo.
+2. Indica desde qué paso deseas iniciar la ejecución.
+3. Haz clic en *Ejecutar flujo* para ver los resultados paso a paso.
+4. Descarga o carga archivos JSON para compartir tus flujos.
+5. Cambia al modo avanzado para editar el código de cualquier nodo.
+6. Activa el **Modo Oscuro** si lo prefieres.
 
 ## Crear nuevos flujos
 

--- a/P8P/app.py
+++ b/P8P/app.py
@@ -19,7 +19,8 @@ def index():
 def run_flujo():
     data = request.get_json()
     flujo_path = os.path.join('flujos', data['flujo'])
-    resultados = ejecutar_flujo(flujo_path)
+    desde = int(data.get('desde', 0))
+    resultados = ejecutar_flujo(flujo_path, desde=desde)
     return jsonify(resultados)
 
 @app.route('/download/<path:archivo>')

--- a/P8P/backend/flujo_engine.py
+++ b/P8P/backend/flujo_engine.py
@@ -14,13 +14,14 @@ def cargar_modulo(nombre):
     return modulo
 
 
-def ejecutar_flujo(ruta_flujo):
+def ejecutar_flujo(ruta_flujo, desde: int = 0):
+    """Ejecuta un flujo JSON a partir del indice indicado."""
     with open(ruta_flujo) as f:
         pasos = json.load(f)
 
     datos = {}
     logs = []
-    for paso in pasos:
+    for paso in pasos[desde:]:
         tipo = paso['tipo']
         params = paso.get('params', {})
         modulo = cargar_modulo(tipo)

--- a/P8P/docs/MANUAL_USUARIO.md
+++ b/P8P/docs/MANUAL_USUARIO.md
@@ -19,11 +19,12 @@ Si deseas iniciar solo el servidor web sin la ventana de escritorio, define la v
 
 ## Cargar y ejecutar flujos
 1. Desde la página principal selecciona uno de los archivos JSON listados en la carpeta `flujos/`.
-2. Presiona **Ejecutar flujo** para procesar cada paso. La salida de un nodo se pasa como entrada al siguiente.
-3. Puedes descargar tus flujos o subir nuevos para compartirlos.
+2. Usa el campo *Desde paso* para iniciar la ejecución en un punto específico.
+3. Presiona **Ejecutar flujo** para procesar cada paso. La salida de un nodo se pasa como entrada al siguiente.
+4. Puedes descargar tus flujos o subir nuevos para compartirlos.
 
 ## Modo avanzado
-Activa el modo desarrollador para editar el código de los nodos directamente desde la interfaz. Esto permite personalizar cada acción según tus necesidades.
+Activa el modo desarrollador para editar el código de los nodos directamente desde la interfaz. También puedes alternar el **Modo Oscuro** según tu preferencia. Esto permite personalizar cada acción según tus necesidades.
 
 ## Crear nuevos nodos
 1. Dentro de la carpeta `nodes/` crea un archivo `.py`.

--- a/P8P/static/style.css
+++ b/P8P/static/style.css
@@ -1,3 +1,5 @@
 body {font-family: Arial, sans-serif;}
 pre {max-height: 300px; overflow: auto;}
 h1 img {vertical-align: middle;}
+body.dark-mode {background-color: #121212; color: #eee;}
+body.dark-mode .bg-light {background-color: #1e1e1e !important;}

--- a/P8P/templates/index.html
+++ b/P8P/templates/index.html
@@ -21,6 +21,10 @@
       {% endfor %}
     </select>
   </div>
+  <div class="mb-3" style="max-width:120px;">
+    <label class="form-label">Desde paso</label>
+    <input type="number" id="desde" class="form-control" value="1" min="1">
+  </div>
   <button id="run" class="btn btn-primary me-2">Ejecutar Flujo</button>
   <button id="download" class="btn btn-secondary me-2">Descargar JSON</button>
   <input type="file" id="flujo-file" class="form-control d-inline w-auto"/>
@@ -28,6 +32,10 @@
   <div class="form-check mt-3">
     <input class="form-check-input" type="checkbox" id="toggle-advanced">
     <label class="form-check-label" for="toggle-advanced">Modo Avanzado</label>
+  </div>
+  <div class="form-check form-switch mt-2">
+    <input class="form-check-input" type="checkbox" id="toggle-dark">
+    <label class="form-check-label" for="toggle-dark">Modo Oscuro</label>
   </div>
   <pre id="resultado" class="mt-3 bg-light p-2"></pre>
   <div id="advanced" style="display:none;">
@@ -60,7 +68,10 @@
         url:'/run',
         method:'POST',
         contentType:'application/json',
-        data: JSON.stringify({flujo: $('#flujo').val()}),
+        data: JSON.stringify({
+          flujo: $('#flujo').val(),
+          desde: parseInt($('#desde').val()) - 1
+        }),
         success:function(data){
           $('#resultado').text(JSON.stringify(data, null, 2));
         }
@@ -94,6 +105,13 @@
           $('#advanced').show();
         } else {
           $('#advanced').hide();
+        }
+      });
+      $('#toggle-dark').change(function(){
+        if(this.checked){
+          $('body').addClass('dark-mode');
+        } else {
+          $('body').removeClass('dark-mode');
         }
       });
     });


### PR DESCRIPTION
## Summary
- enable optional dark mode and start flow from a specific step
- show new controls on the main interface
- document how to use dark mode and the start index

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68408aea4fc88332955ce54cd7c6cfb7